### PR TITLE
Fix for Debian 9

### DIFF
--- a/mailauto.sh
+++ b/mailauto.sh
@@ -107,6 +107,10 @@ InstallRequiredPackage()
 #Array of required packages
 
     local INSTALL_PACKAGES=(mysql-server dovecot-core dovecot-imapd dovecot-mysql dovecot-lmtpd postfix postfix-mysql)
+    #Changes for Debian 9
+    if [[ $(lsb_release -cs) == "stretch" ]]; then
+      INSTALL_PACKAGES[0] ="default-mysql-server"
+    fi
 
 #Check if packages are installed
     for package in ${INSTALL_PACKAGES[*]}


### PR DESCRIPTION
Hi Lexidus,

in Debian 9 was 'mysql-server' renamed in 'default-mysql-server'.
I've added a check that replaces the package in array if stretch is detected.

Best regards,
addictedtoberlin